### PR TITLE
EDIT:ERROR (Fix MinGW compatibility)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 ._*
+build*/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 ._*
+build*

--- a/README.md
+++ b/README.md
@@ -21,49 +21,88 @@ mcfx is free software and licensed under the GNU General Public License version 
 prerequisites for building
 --------------
 
-- cmake, working build environment
+CMake, working build environment
 
-Install LINUX Libraries (Debian, Ubuntu):
+- **Linux:**  
+    Install LINUX Libraries (Debian, Ubuntu):
 
+    ```
+    sudo apt install libasound2-dev libjack-jackd2-dev \
+        ladspa-sdk \
+        libcurl4-openssl-dev  \
+        libfreetype6-dev \
+        libx11-dev libxcomposite-dev libxcursor-dev libxcursor-dev libxext-dev libxinerama-dev libxrandr-dev libxrender-dev \
+        libwebkit2gtk-4.0-dev \
+        libglu1-mesa-dev mesa-common-dev \
+        libfftw3-dev \
+        libzita-convolver3 \
+        libzita-convolver-dev
+    ```
+
+- **Windows x64:**  
+    Download [FFTW](https://www.fftw.org/) for [Windows](https://www.fftw.org/install/windows.html) 64bit and run the command `lib /machine:x64 /def:libfftw3f-3.def` from the Visual Studio Developer Command Prompt to generate *libfftw3f-3.lib*.  
+    Alternatively, run the command `lib /def:libfftw3f-3.def` from the `x64 Native Tools Command Prompt for VS`.
+    Note that this simpler command, instructed by the FFTW documentation, will generate a 32bit library when called from the default Developer Command Prompt or Powershell (and therefore fail to link)
+
+Make sure of using fftw-3.3.6-pl2 or later, as earlier versions do not contain the `fftwf_make_planner_thread_safe()` function.
+
+Clone the repository with the submodules:
 ```
-sudo apt install libasound2-dev libjack-jackd2-dev \
-    ladspa-sdk \
-    libcurl4-openssl-dev  \
-    libfreetype6-dev \
-    libx11-dev libxcomposite-dev libxcursor-dev libxcursor-dev libxext-dev libxinerama-dev libxrandr-dev libxrender-dev \
-    libwebkit2gtk-4.0-dev \
-    libglu1-mesa-dev mesa-common-dev \
-	libfftw3-dev \
-	libzita-convolver3 \
-	libzita-convolver-dev
+git clone --recurse-submodules https://github.com/kronihias/mcfx/
 ```
 
-howto build yourself:
+
+
+Howto build yourself:
 --------------
 
-- use cmake gui or cmake/ccmake from terminal:
+Use **cmake gui** or **cmake/ccmake** from terminal to configure the build.
 
-- *NUM_CHANNELS* adjusts the number of input/output channels
+1. Create a folder in the *mcfx* folder eg. *BUILD*
+    ```
+    mkdir BUILD # On Linux, MacOS or Windows Powershell    
+    ```
+2. Run cmake or ccmake from the *BUILD* folder, or use the cmake gui and press *Configure*.  
+    In the terminal:
+    ```
+    cd BUILD
+    ccmake ..
+    ```
+    Press the *C* key.
+      
+    If using the GUI instead, select the target build system (e.g., in Windows use Visual Studio or MinGW).
+3. Set the [Build Parameters](#build-parameters),  *Configure* again. Then *Generate*.
+4. Build the project with the selected build system (e.g., Visual Studio, Xcode, or make).  
+    E.g., for Linux:
+    ```
+    make -j$(nproc) config=Release
+    ```
+    `-j$(nproc)` will instruct make to use all available cores for the build.
+5. After a successful build, find the binaries in `BUILD/_bin/` or `BUILD/vst/` and copy to system VST folder  
 
-**TERMINAL:**
-
-- create a folder in the *mcfx* folder eg. *BUILD*
-
-*mcfx/BUILD> $ ccmake ..*
-
-- adjust NUM_CHANNELS 
-
-then
-*mcfx/BUILD> $ make*
-
-- find the binaries in the *mcfx/BUILD/_bin* folder and copy to system VST folder
-
-**VST installation folders:**
+    **VST installation folders:**
 
 
-- MacOSX: `/Library/Audio/Plug-Ins/VST`
-- Windows: eg. `C:\Programm Files\Steinberg\VstPlugins`
-- Linux: `/usr/lib/lxvst` or `/usr/local/lib/lxvst`
+    - MacOSX: `/Library/Audio/Plug-Ins/VST`
+    - Windows: `C:\Program Files\Steinberg\VstPlugins`, `C:\Program Files\Common Files\VST2`, or `C:\Program Files\VSTPlugins`
+    - Linux: `~/.vst/`, `/usr/lib/lxvst` or `/usr/local/lib/lxvst`
+
+## Build Parameters
+
+- **``NUM_CHANNELS``** - Number of input/output channels for each plugin. Default is 36.
+- **``MAX_DELAYTIME_S``** - Maximum delay time for mcfx_delay in seconds. Default is 0.5s.
+- **``BUILD_STANDALONE``** - Build standalone applications. Default is OFF.
+- **``BUILD_VST``** - Build VST2 plugins. Default is ON.
+- **``BUILD_LV2``** - Build LV2 plugins. Default is ON.
+- **``VST2SDKPATH``** - Path to the VST2 SDK. Default is "~/SDKs/vstsdk2.4"
+- **``WITH_ZITA_CONVOLVER``** - Build with zita-convolver (better performance under Linux). Default is OFF.
+---
+- **``FFTW3F_LIBRARY``** - Path to the FFTW3F library file (Note the final **f**!).  
+    - On Linux this should point to the `.so` shared library file, e.g., `/usr/lib/x86_64-linux-gnu/libfftw3f-3.so`.
+    - On Windows with Visual Studio, this should point to the `.lib` file generated in a [previous step](#prerequisites-for-building), e.g., `C:/Program Files/fftw-3.3.6-pl2-dll64/libfftw3f-3.lib`.
+    - On Windows with MinGW, this should point to the `.dll` dynamic library file, e.g., `C:/Program Files/fftw-3.3.6-pl2-dll64/libfftw3f-3.dll`.
+- **``FFTW3F_INCLUDE_DIR``** - Path to the FFTW3F include directory, e.g., `/usr/include`.
+- [**``FFTW3F_THREADS_LIBRARY``**] - If present (e.g., on Linux), this should point to the `.so` file for the FFTW3F threads library, e.g., `/usr/lib/x86_64-linux-gnu/libfftw3f_threads.so`.
 
 plug-ins explained:
 ==============

--- a/mcfx_convolver/Source/MtxConv.h
+++ b/mcfx_convolver/Source/MtxConv.h
@@ -48,7 +48,7 @@
 
 inline void* aligned_malloc(size_t size, size_t align) {
     void *result;
-#ifdef _MSC_VER
+#if defined(_MSC_VER) or defined(_WIN32)
     result = _aligned_malloc(size, align);
 #else
     if(posix_memalign(&result, align, size)) result = 0;
@@ -57,7 +57,7 @@ inline void* aligned_malloc(size_t size, size_t align) {
 }
 
 inline void aligned_free(void *ptr) {
-#ifdef _MSC_VER
+#if defined(_MSC_VER) or defined(_WIN32)
     _aligned_free(ptr);
 #else
     free(ptr);

--- a/mcfx_convolver/Source/PluginEditor.cpp
+++ b/mcfx_convolver/Source/PluginEditor.cpp
@@ -184,7 +184,9 @@ box_maxpart("new combobox")
     tgl_save_preset.setToggleState(true, dontSendNotification);
     tgl_save_preset.setColour(ToggleButton::textColourId, Colours::white);
 
-    setSize (350, 330);
+    // setResizable (true,true);                                    // Uncomment to make resizable
+    // setResizeLimits(window_width, window_height, 1200, 1200);    // Uncomment to make resizable
+    setSize (window_width, window_height);
 
     UpdateText();
 
@@ -218,10 +220,10 @@ void Mcfx_convolverAudioProcessorEditor::paint (Graphics& g)
                                        Colours::black,
                                        (float) (proportionOfWidth (0.1143f)), (float) (proportionOfHeight (0.0800f)),
                                        true));
-    g.fillRect (0, 0, 350, 330);
+    g.fillRect (0, 0, window_width, window_height);
 
     g.setColour (Colours::black);
-    g.drawRect (0, 0, 350, 330, 1);
+    g.drawRect (0, 0, window_width, window_height, 1);
 
     g.setColour (Colour (0x410000ff));
     g.fillRoundedRectangle (18.0f, 132.0f, 190.0f, 77.0f, 10.0000f);
@@ -230,20 +232,20 @@ void Mcfx_convolverAudioProcessorEditor::paint (Graphics& g)
     g.setFont (Font (17.2000f, Font::bold));
 
     g.drawText ("MCFX-CONVOLVER",
-                1, 3, 343, 25,
+                1, 3, fromRight(7), 25,
                 Justification::centred, true);
 
     g.setFont (Font (12.4000f, Font::plain));
     g.drawText ("multichannel non-equal partioned convolution matrix",
-                1, 23, 343, 25,
+                1, 23, fromRight(7), 25,
                 Justification::centred, true);
 
     g.setFont (Font (12.4000f, Font::plain));
     g.drawText ("First Partition Size",
-                200, 104, 135, 30,
+                fromRight(150), 104, 135, 30,
                 Justification::centredRight, true);
     g.drawText ("Maximum Partition Size",
-              200, 145, 135, 30,
+              fromRight(150), 145, 135, 30,
               Justification::centredRight, true);
 
 
@@ -259,27 +261,35 @@ void Mcfx_convolverAudioProcessorEditor::paint (Graphics& g)
 
 void Mcfx_convolverAudioProcessorEditor::resized()
 {
+    auto area = getLocalBounds();
+    window_height = area.getHeight();
+    window_width = area.getWidth();
+
     label.setBounds (16, 134, 140, 24);
-    txt_preset.setBounds (72, 50, 200, 24);
+    txt_preset.setBounds (72, 50, fromRight(150), 24);
     label5.setBounds (8, 50, 56, 24);
-    txt_debug.setBounds (16, 214, 320, 96);
-    btn_open.setBounds (280, 50, 56, 24);
+    // txt_debug.setBounds (16, 214, 320, 96); // Original size
+    txt_debug.setBounds (16, 214, fromRight(30), frombottom(234)); //resizeable compliant
+
+    btn_open.setBounds (fromRight(70), 50, 56, 24);
     label2.setBounds (16, 158, 140, 24);
     label3.setBounds (16, 182, 140, 24);
-    label4.setBounds (24, 310, 64, 16);
-    lbl_skippedcycles.setBounds(110, 310, 150, 16);
+    label4.setBounds (24, frombottom(20), 64, 16);
+    lbl_skippedcycles.setBounds(110, frombottom(20), 150, 16);
     num_ch.setBounds (150, 134, 40, 24);
     num_spk.setBounds (150, 158, 40, 24);
     num_hrtf.setBounds (150, 182, 40, 24);
-    btn_preset_folder.setBounds (245, 80, 94, 24);
+    btn_preset_folder.setBounds (fromRight(105), 80, 94, 24);
 
-    box_conv_buffer.setBounds (270, 126, 67, 20);
-    box_maxpart.setBounds (270, 169, 65, 20);
+    box_conv_buffer.setBounds (fromRight(80), 126, 67, 20);
+    box_maxpart.setBounds (fromRight(80), 169, 65, 20);
 
     tgl_save_preset.setBounds(16, 79, 200, 24);
 
     txt_rcv_port.setBounds(146, 108, 40, 18);
     tgl_rcv_active.setBounds(16, 105, 130, 24);
+
+    repaint();
 }
 
 void Mcfx_convolverAudioProcessorEditor::timerCallback()

--- a/mcfx_convolver/Source/PluginEditor.h
+++ b/mcfx_convolver/Source/PluginEditor.h
@@ -118,6 +118,12 @@ private:
     ToggleButton tgl_rcv_active;
     ToggleButton tgl_save_preset;
 
+    int window_width = 450,
+        window_height = 330;  // Current window height, to support resizing of debug window
+    // Lambdas to simplify measuring from the right and bottom of the plugin window
+    std::function<int(int)> fromRight = [this](int c) { jassert(window_width>=0); return window_width-c; };
+    std::function<int(int)> frombottom = [this](int c) { jassert(window_height>=0); return window_height-c; };
+    
     std::unique_ptr<AlertWindow> asyncAlertWindow;
 
     LookAndFeel_V3 MyLookAndFeel;

--- a/mcfx_convolver/Source/PluginProcessor.cpp
+++ b/mcfx_convolver/Source/PluginProcessor.cpp
@@ -61,7 +61,7 @@ Mcfx_convolverAudioProcessor::Mcfx_convolverAudioProcessor() :
     std::cout << "Search dir:" << presetDir.getFullPathName() << std::endl;
 
 	String debug;
-    debug << "Search dir: " << presetDir.getFullPathName() << "\n\n";
+    debug << "Search dir: " << presetDir.getFullPathName();
 
     DebugPrint(debug);
 
@@ -286,7 +286,7 @@ void Mcfx_convolverAudioProcessor::run()
 
 void Mcfx_convolverAudioProcessor::LoadConfigurationAsync(File configFile)
 {
-    DebugPrint("Loading preset...\n\n");
+    DebugPrint("Loading preset...");
     _desConfigFile = configFile;
     startThread(Thread::Priority::normal);
 }
@@ -393,7 +393,7 @@ void Mcfx_convolverAudioProcessor::LoadConfiguration(File configFile)
     {
 
         String debug;
-        debug << "Configuration file does not exist:\n" << configFile.getFullPathName() << "\n\n";
+        debug << "Configuration file does not exist:\n" << configFile.getFullPathName();
 
         //std::cout << debug << std::endl;
         DebugPrint(debug);
@@ -410,7 +410,8 @@ void Mcfx_convolverAudioProcessor::LoadConfiguration(File configFile)
 
         std::cout << "Unloading Config..." << std::endl;
         UnloadConfiguration();
-        DebugPrint("", true); // clear debug window
+        // DebugClear(); // clear debug window
+        DebugPrint("Config Unloaded...");
         std::cout << "Config Unloaded..." << std::endl;
     }
 
@@ -420,7 +421,7 @@ void Mcfx_convolverAudioProcessor::LoadConfiguration(File configFile)
     _ConvBufferSize = nextPowerOfTwo(_ConvBufferSize);
 
     String debug;
-    debug << "\ntrying to load " << configFile.getFullPathName() << "\n\n";
+    debug << "trying to load " << configFile.getFullPathName();
 
     DebugPrint(debug);
 
@@ -537,7 +538,7 @@ void Mcfx_convolverAudioProcessor::LoadConfiguration(File configFile)
 
                 String debug;
                 debug << "ERROR: channel assignment not feasible: In: " << in_ch << " Out: " << out_ch;
-                DebugPrint(debug << "\n");
+                DebugPrint(debug);
 
 
             } else {
@@ -554,12 +555,12 @@ void Mcfx_convolverAudioProcessor::LoadConfiguration(File configFile)
                     debug << "conv # " << conv_data.getNumIRs() << " " << IrFilename.getFullPathName() << " (" << TempAudioBuffer.getNumSamples() << " smpls) loaded";
                     if (src_samplerate != _SampleRate)
                       debug << " (resampled to " << conv_data.getLength(conv_data.getNumIRs()-1) <<  " smpls)";
-                    DebugPrint(debug << "\n");
+                    DebugPrint(debug);
 
                 } else {
                     String debug;
                     debug << "ERROR: not loaded: " << IrFilename.getFullPathName();
-                    DebugPrint(debug << "\n");
+                    DebugPrint(debug);
 
                 }
 
@@ -635,7 +636,7 @@ void Mcfx_convolverAudioProcessor::LoadConfiguration(File configFile)
             {
                 String debug;
                 debug << "ERROR: Number of input channels not feasible: " << inchannels;
-                DebugPrint(debug << "\n");
+                DebugPrint(debug);
 
                 return;
             }
@@ -653,7 +654,7 @@ void Mcfx_convolverAudioProcessor::LoadConfiguration(File configFile)
                 {
                     String debug;
                     debug << "ERROR: length of wav file is not multiple of irLength*numinchannels!" << IrFilename.getFullPathName();
-                    DebugPrint(debug << "\n");
+                    DebugPrint(debug);
 
                     return;
                 }
@@ -662,7 +663,7 @@ void Mcfx_convolverAudioProcessor::LoadConfiguration(File configFile)
                 {
                     String debug;
                     debug << "Input/Output channel assignement not feasible. Not enough input/output channels of the plugin. Need Input: " << inchannels << " Output: " << numOutChannels;
-                    DebugPrint(debug << "\n");
+                    DebugPrint(debug);
 
                     return;
                 }
@@ -687,13 +688,13 @@ void Mcfx_convolverAudioProcessor::LoadConfiguration(File configFile)
                 }
 
                 String debug;
-                debug << "loaded " << conv_data.getNumIRs() << " filters with\nlength " << length << "\ninput channels: " << inchannels << "\noutput channels: " << numOutChannels << "\nfilename: " << IrFilename.getFileName();
-                DebugPrint(debug << "\n\n");
+                debug << "loaded " << conv_data.getNumIRs() << " filters with: length " << length << ", input channels: " << inchannels << ", output channels: " << numOutChannels << ", filename: " << IrFilename.getFileName();
+                DebugPrint(debug);
 
             } else {
                 String debug;
                 debug << "ERROR: not loaded: " << IrFilename.getFullPathName();
-                DebugPrint(debug << "\n");
+                DebugPrint(debug);
 
                 return;
             }
@@ -770,9 +771,10 @@ void Mcfx_convolverAudioProcessor::LoadConfiguration(File configFile)
 
 
     debug.clear();
-    debug << "Configuration loaded, maximum filter length: " << String(conv_data.getMaxLengthInSeconds(), 2) << "[s], " << conv_data.getMaxLength() << " [smpls] \n";
-    debug << "Plugin Latency: " << getLatencySamples() << " [smpls] \n";
-    DebugPrint(debug << "\n\n");
+    debug << "Configuration loaded, maximum filter length: " << String(conv_data.getMaxLengthInSeconds(), 2) << "[s], " << conv_data.getMaxLength() << " [smpls]";
+    DebugPrint(debug);
+    debug << "Plugin Latency: " << getLatencySamples() << " [smpls]";
+    DebugPrint(debug);
 
     sendChangeMessage(); // notify editor
 
@@ -820,7 +822,7 @@ bool Mcfx_convolverAudioProcessor::loadIr(AudioSampleBuffer* IRBuffer, const Fil
     {
         String debug;
         debug << "ERROR: file does not exist!";
-        DebugPrint(debug << "\n");
+        DebugPrint(debug);
         return false;
     }
 
@@ -834,7 +836,7 @@ bool Mcfx_convolverAudioProcessor::loadIr(AudioSampleBuffer* IRBuffer, const Fil
     if (!reader) {
         String debug;
         debug << "ERROR: could not read impulse response file!";
-        DebugPrint(debug << "\n");
+        DebugPrint(debug);
         return false;
     }
 
@@ -849,7 +851,7 @@ bool Mcfx_convolverAudioProcessor::loadIr(AudioSampleBuffer* IRBuffer, const Fil
     if (wav_length <= 0) {
         String debug;
         debug << "ERROR: zero samples in impulse response file!";
-        DebugPrint(debug << "\n");
+        DebugPrint(debug);
         return false;
     }
 
@@ -858,13 +860,13 @@ bool Mcfx_convolverAudioProcessor::loadIr(AudioSampleBuffer* IRBuffer, const Fil
 
         String debug;
         debug << "Warning: not enough samples in impulse response file, reading maximum number of samples: " << String(length);
-        DebugPrint(debug << "\n");
+        DebugPrint(debug);
     }
 
     if ((int)reader->numChannels <= channel) {
         String debug;
         debug << "ERROR: wav file doesn't have enough channels: " << String(reader->numChannels);
-        DebugPrint(debug << "\n");
+        DebugPrint(debug);
         return false;
     }
 
@@ -944,6 +946,11 @@ void Mcfx_convolverAudioProcessor::setMaxPartitionSize(unsigned int maxsize)
 
 void Mcfx_convolverAudioProcessor::setOscIn(bool arg)
 {
+    
+String debug;
+debug << "OSC receiver " << (arg?"enabled":"disabled");
+DebugPrint(debug);
+
   if (arg) {
 
     if (oscReceiver.connect(_osc_in_port))
@@ -954,7 +961,7 @@ void Mcfx_convolverAudioProcessor::setOscIn(bool arg)
     }
     else
     {
-      DebugPrint("Could not open UDP port, try a different port.\n");
+      DebugPrint("Could not open UDP port, try a different port.");
     }
 
 
@@ -976,6 +983,11 @@ bool Mcfx_convolverAudioProcessor::getOscIn()
 
 void Mcfx_convolverAudioProcessor::setOscInPort(int port)
 {
+
+    String debug;
+    debug << "Set OSCreceiver port to " << juce::String(port);
+    DebugPrint(debug);
+
   _osc_in_port = port;
 
   if (_osc_in)
@@ -994,19 +1006,22 @@ void Mcfx_convolverAudioProcessor::oscMessageReceived(const OSCMessage & message
 {
   if (message.getAddressPattern() == "/reload")
   {
-    DebugPrint("Received Reload via OSC (/reload).\n");
+    DebugPrint("Received Reload via OSC (/reload).");
     ReloadConfiguration();
   }
   else if (message.getAddressPattern() == "/load")
   {
 
-    DebugPrint("Received Load via OSC (/load).\n");
+    DebugPrint("Received Load via OSC (/load).");
 
     if (message.size() < 1)
       return;
 
     if (message[0].isString())
       LoadPresetByName(message[0].getString());
+  }
+  else {
+    DebugPrint("Received unknown OSC message");
   }
 }
 
@@ -1050,14 +1065,33 @@ void Mcfx_convolverAudioProcessor::DeleteTemporaryFiles()
     _cleanUpFilesOnExit.clear();
 }
 
-void Mcfx_convolverAudioProcessor::DebugPrint(String debugText, bool reset)
+/**
+ * @brief Clear the debug text
+ * Clear the debug text that is displayed in the Debug window
+ */
+void Mcfx_convolverAudioProcessor::DebugClear()
 {
     ScopedLock lock(_DebugTextMutex);
     String temp;
+    temp << "";
 
-    if (!reset)
-        temp << debugText;
+    _DebugText = temp;
+}
 
+
+/**
+ * @brief Print a string to the debug window and add a newline
+ * @param debugText The string to print to the debug window
+ */
+void Mcfx_convolverAudioProcessor::DebugPrint(const String& debugText)
+{
+    
+    ScopedLock lock(_DebugTextMutex);
+    String temp;
+
+    juce::String currentTime = Time::getCurrentTime().formatted("%H:%M:%S"); // Log current time for better debugging
+
+    temp << currentTime << " | "<< debugText << "\n";
     temp << _DebugText;
 
     // std::cout << debugText << std::endl;
@@ -1114,7 +1148,7 @@ void Mcfx_convolverAudioProcessor::LoadPresetByName(String presetName)
     else
     { // preset not found -> post!
         String debug_msg;
-        debug_msg << "ERROR loading preset: " << presetName << ", Preset not found in search folder!\n\n";
+        debug_msg << "ERROR loading preset: " << presetName << ", Preset not found in search folder!";
         DebugPrint(debug_msg);
     }
 
@@ -1202,7 +1236,7 @@ void Mcfx_convolverAudioProcessor::setStateInformation (const void* data, int si
         // load config from chunk data
         if (xmlState->hasAttribute("configData") && _storeConfigDataInProject.get())
         {
-          DebugPrint("Load configuration from saved project data\n");
+          DebugPrint("Load configuration from saved project data");
           // todo....!
           MemoryBlock tempMem;
           tempMem.fromBase64Encoding(xmlState->getStringAttribute("configData"));

--- a/mcfx_convolver/Source/PluginProcessor.h
+++ b/mcfx_convolver/Source/PluginProcessor.h
@@ -158,7 +158,10 @@ private:
 
     void DeleteTemporaryFiles();
 
-    void DebugPrint(String debugText, bool reset=false);
+    void DebugClear();
+    void DebugPrint(const String& debugText);
+
+
 
     String _DebugText;
     CriticalSection _DebugTextMutex;

--- a/mcfx_filter/Source/PluginProcessor.h
+++ b/mcfx_filter/Source/PluginProcessor.h
@@ -43,7 +43,7 @@
 
 inline void* aligned_malloc(size_t size, size_t align) {
     void *result;
-#ifdef _MSC_VER
+#if defined(_MSC_VER) or defined(_WIN32)
     result = _aligned_malloc(size, align);
 #else
     if(posix_memalign(&result, align, size)) result = 0;


### PR DESCRIPTION
EDIT: I compromised the content of this PR therefore I closed it (see comment below)

~~Changed lines that used the preprocessor define `_MSC_VER` from MS VSC++ to determine if compiling for Windows. 
This is to support Windows build systems other than VisualStudio, such as MinGW. 
Previously to the fix, compiling with MinGW would fail because `_MSC_VER` was not defined, and the `aligned_malloc` function defaulted to using `posix_memalign`.
The README was updated with build instructions for Windows and a list of the CMake variables~~
